### PR TITLE
refactor: FParticleEmitterInstance 리팩토링

### DIFF
--- a/Mundi/Source/Runtime/Engine/Particles/ParticleEmitterInstance.cpp
+++ b/Mundi/Source/Runtime/Engine/Particles/ParticleEmitterInstance.cpp
@@ -24,21 +24,11 @@ FParticleEmitterInstance::FParticleEmitterInstance()
 
 FParticleEmitterInstance::~FParticleEmitterInstance()
 {
-    if (ParticleData)
-    {
-        delete[] ParticleData;
-        ParticleData = nullptr;
-    }
-    if (ParticleIndices)
-    {
-        delete[] ParticleIndices;
-        ParticleIndices = nullptr;
-    }
+    ClearParticleData();
 }
 
-void FParticleEmitterInstance::InitParticles(int32 InMaxParticles)
+void FParticleEmitterInstance::InitParticles()
 {
-    MaxActiveParticles = InMaxParticles;
     ParticleData = new uint8[MaxActiveParticles * ParticleStride];
     ParticleIndices = new int32[MaxActiveParticles];
     for (int32 i = 0; i < MaxActiveParticles; ++i)
@@ -50,38 +40,18 @@ void FParticleEmitterInstance::InitParticles(int32 InMaxParticles)
 
 void FParticleEmitterInstance::Initialize(UParticleEmitter* InTemplate, UParticleSystemComponent* InComponent, int32 InLODIndex, int32 InMaxActiveParticles)
 {
-    if (ParticleData)
-    {
-        delete[] ParticleData;
-        ParticleData = nullptr;
-    }
-    if (ParticleIndices)
-    {
-        delete[] ParticleIndices;
-        ParticleIndices = nullptr;
-    }
+    ClearParticleData();
 
     EmitterTemplate = InTemplate;
     Component = InComponent;
 
+    // 파티클 최댓값: 지정값 우선, 없으면 이미터 템플릿 기준
+    MaxActiveParticles = (InMaxActiveParticles > 0) ? InMaxActiveParticles :
+        (EmitterTemplate ? EmitterTemplate->MaxParticleCount : 0);
+
     // @TODO: LOD 구현은 후순위. 구현 전까지 SetLODLevel 호출하지 말 것. 
     //SetLODLevel(InLODIndex);
     SetLODLevel(0);
-    ParticleStride = CalculateParticleStride(); // 페이로드 요구량 + 정렬 반영
-
-    // 파티클 최댓값: 지정값 우선, 없으면 이미터 템플릿 기준
-    const int32 RequestedMax = (InMaxActiveParticles > 0) ? InMaxActiveParticles :
-        (EmitterTemplate ? EmitterTemplate->MaxParticleCount : 0);
-
-    if (RequestedMax > 0)
-    {
-        InitParticles(RequestedMax);
-    }
-    else
-    {
-        MaxActiveParticles = 0;
-        ActiveParticles = 0;
-    }
 
     SpawnFraction = 0.0f;
     SecondsSinceCreation = 0.0f;
@@ -99,31 +69,20 @@ uint32 FParticleEmitterInstance::CalculateParticleStride() const
     return AlignUp(ParticleSize, ParticleStrideAlignment);
 }
 
-void FParticleEmitterInstance::ReallocateParticleData(uint32 NewStride)
+void FParticleEmitterInstance::ReallocateParticleData(uint32 NewStride, int32 NewMaxActiveParticles)
 {
-    if (NewStride == ParticleStride)
-    {
-        return;
-    }
-
     ParticleStride = NewStride;
+    MaxActiveParticles = NewMaxActiveParticles;
 
-    if (ParticleData)
+    ClearParticleData();
+
+    if (ParticleStride > 0 && MaxActiveParticles > 0)
     {
-        delete[] ParticleData;
-        ParticleData = nullptr;
+        InitParticles();
     }
-    if (ParticleIndices)
+    else
     {
-        delete[] ParticleIndices;
-        ParticleIndices = nullptr;
-    }
-
-    ActiveParticles = 0;
-
-    if (MaxActiveParticles > 0)
-    {
-        InitParticles(MaxActiveParticles);
+		UE_LOG("ERROR: FParticleEmitterInstance::ReallocateParticleData called with invalid parameters.(ParticleStride: %d, MaxActiveParticles: %d", ParticleStride, MaxActiveParticles);
     }
 }
 
@@ -337,7 +296,7 @@ void FParticleEmitterInstance::SetLODLevel(int32 LODIndex)
             CurrentLODLevel = nullptr;
             CurrentLODLevelIndex = -1;
             const uint32 BaseStride = AlignUp(sizeof(FBaseParticle), ParticleStrideAlignment);
-            ReallocateParticleData(BaseStride);
+            ReallocateParticleData(BaseStride, MaxActiveParticles);
         }
         return;
     }
@@ -357,7 +316,7 @@ void FParticleEmitterInstance::SetLODLevel(int32 LODIndex)
     CurrentLODLevelIndex = LODIndex;
 
     const uint32 NewStride = CalculateParticleStride();
-    ReallocateParticleData(NewStride);
+    ReallocateParticleData(NewStride, MaxActiveParticles);
 }
 
 FBaseParticle* FParticleEmitterInstance::GetParticle(int32 ActiveIndex)
@@ -372,4 +331,19 @@ const FBaseParticle* FParticleEmitterInstance::GetParticle(int32 ActiveIndex) co
     if (ActiveIndex < 0 || ActiveIndex >= ActiveParticles)
         return nullptr;
     return reinterpret_cast<const FBaseParticle*>(ParticleData + ParticleIndices[ActiveIndex] * ParticleStride);
+}
+
+void FParticleEmitterInstance::ClearParticleData()
+{
+    if (ParticleData)
+    {
+        delete[] ParticleData;
+        ParticleData = nullptr;
+    }
+    if (ParticleIndices)
+    {
+        delete[] ParticleIndices;
+        ParticleIndices = nullptr;
+    }
+    ActiveParticles = 0;
 }

--- a/Mundi/Source/Runtime/Engine/Particles/ParticleEmitterInstance.h
+++ b/Mundi/Source/Runtime/Engine/Particles/ParticleEmitterInstance.h
@@ -28,8 +28,8 @@ struct FParticleEmitterInstance
     uint8* ParticleData;                           // 연속된 파티클 메모리 블록
     int32* ParticleIndices;                        // 활성 파티클 인덱스 배열 (논리 인덱스 -> 데이터 배열 실제 인덱스 매핑)
     uint32 ParticleStride;                         // sizeof(FBaseParticle) + 추가 페이로드
-    int32 ActiveParticles;                         // 현재 활성 파티클 수
     int32 MaxActiveParticles;                      // 최대 파티클 수
+    int32 ActiveParticles;                         // 현재 활성 파티클 수
 
     // 스폰 제어
     float SpawnFraction;                           // 누적 스폰 잔량
@@ -39,19 +39,6 @@ struct FParticleEmitterInstance
     ~FParticleEmitterInstance();
 
     /**
-     * @brief 주어진 값과 정렬 단위에 맞춰 값을 올림 정렬합니다.
-     * @note Alignment는 2의 거듭제곱이어야 합니다.
-     */
-    static uint32 AlignUp(uint32 Value, uint32 Alignment)
-    {
-        const uint32 Mask = Alignment - 1u;
-        return (Value + Mask) & ~Mask;
-    }
-
-    // 메모리 할당
-    void InitParticles(int32 InMaxParticles);
-
-    /**
 	 * @brief 상위 초기화를 수행합니다. (템플릿/컴포넌트/LOD와 메모리 풀 준비)
 	 * @param InTemplate 이미터 템플릿
 	 * @param InComponent 소유 파티클 시스템 컴포넌트
@@ -59,12 +46,6 @@ struct FParticleEmitterInstance
 	 * @param InMaxActiveParticles 최대 활성 파티클 수 (0이하 값을 주면 템플릿 설정을 사용합니다)
      */
     void Initialize(UParticleEmitter* InTemplate, UParticleSystemComponent* InComponent, int32 InLODIndex, int32 InMaxActiveParticles);
-
-    /** @brief: 모듈 요구 바이트를 합산해 정렬(align)까지 고려한 Stride를 계산합니다. */
-    uint32 CalculateParticleStride() const;
-
-    /** @brief: LOD 변경 등으로 Stride가 달라질 때 기존 파티클 메모리를 정리하고 새 Stride로 재할당 */
-    void ReallocateParticleData(uint32 NewStride);
 
     /** @brief 한 프레임 틱 업데이트를 수행합니다. (스폰 → 업데이트 → 파이널 업데이트 → Kill) */
     void Tick(float DeltaTime);
@@ -96,4 +77,29 @@ struct FParticleEmitterInstance
     // Stride 기반 파티클 접근
     FBaseParticle* GetParticle(int32 ActiveIndex);
     const FBaseParticle* GetParticle(int32 ActiveIndex) const;
+
+private:
+    // 내부 헬퍼 함수
+
+    /**
+     * @brief 주어진 값과 정렬 단위에 맞춰 값을 올림 정렬합니다.
+     * @note Alignment는 2의 거듭제곱이어야 합니다.
+     */
+    static uint32 AlignUp(uint32 Value, uint32 Alignment)
+    {
+        const uint32 Mask = Alignment - 1u;
+        return (Value + Mask) & ~Mask;
+    }
+
+    /** @brief 메모리를 할당합니다. ParticleStride, MaxActiveParticles 설정 후 수행해야 합니다. */
+    void InitParticles();
+
+    /** @brief 파티클 데이터/인덱스 버퍼 해제 및 ActiveParticles 초기화 */
+    void ClearParticleData();
+
+    /** @brief 모듈 요구 바이트를 합산해 정렬(align)까지 고려한 Stride를 계산합니다. */
+    uint32 CalculateParticleStride() const;
+
+    /** @brief Stride/MaxActive를 변경하고 버퍼 재할당 (멤버 설정 포함) */
+    void ReallocateParticleData(uint32 NewStride, int32 NewMaxActiveParticles);
 };


### PR DESCRIPTION
- 중복 코드 제거
- 분산된 멤버변수 설정 및 메모리 할당 로직을 SetLODLevel과 ReallocateParticleData 메소드로 모아줌.
